### PR TITLE
adding 5 to 7 button

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,15 +10,10 @@ reviews:
     enabled: true
     drafts: false
 
-    # Quality gates
-  pre_merge_checks:
-    title:
-      mode: "error"
-      requirements: "Use conventional commit format"
-    description:
-      mode: "warning"
-
   # Label management
   suggested_labels: true
   auto_apply_labels: true
+
+
+  poem: false
   

--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
         <button class="art-button" onclick="changeTheme()">Click Me 2!!!</button>
         <button class="art-button" onclick="changeTheme()">Click Me 3!!!</button>
         <button class="art-button" onclick="changeTheme()">Click Me 4!!!</button>
+        <button class="art-button" onclick="changeTheme()">Click Me 5!!!</button>
+        <button class="art-button" onclick="changeTheme()">Click Me 6!!!</button>
+        <button class="art-button" onclick="changeTheme()">Click Me 7!!!</button>
 
     </div>
 


### PR DESCRIPTION
Resolves SPI-26


testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three additional theme-change buttons in the art section labeled “Click Me 5!!!”, “Click Me 6!!!”, and “Click Me 7!!!”, expanding buttons from four to seven; they behave like existing theme-change controls.

* **Chores**
  * Updated repository configuration for review/merge checks (internal settings adjusted).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->